### PR TITLE
Centralize chat completions via service layer

### DIFF
--- a/app/services/chat_completion_service.py
+++ b/app/services/chat_completion_service.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+from openai import OpenAI
+
+
+class ChatCompletionService:
+    """
+    Service layer for chat completions.
+
+    - Owns OpenAI-compatible client creation and invocation.
+    - Does NOT care about HTTP/FastAPI routing.
+    - Returns plain text for now (minimal stable contract).
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> None:
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        self.base_url = base_url or os.getenv("OPENAI_BASE_URL")
+        self.model = model or os.getenv("OPENAI_MODEL")
+
+        if not self.api_key:
+            raise ValueError("Missing OPENAI_API_KEY")
+        if not self.model:
+            raise ValueError("Missing OPENAI_MODEL")
+
+        # base_url can be None for real OpenAI; OK.
+        self.client = OpenAI(api_key=self.api_key, base_url=self.base_url)
+
+    def create(
+        self,
+        messages: List[Dict[str, Any]],
+        temperature: float = 0.7,
+        max_tokens: int = 512,
+    ) -> str:
+        """
+        Create a single-turn or multi-turn chat completion.
+
+        The caller is responsible for providing messages.
+        This service does not manage conversation state.
+        """
+        resp = self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        return resp.choices[0].message.content or ""

--- a/scripts/chat_demo.py
+++ b/scripts/chat_demo.py
@@ -1,42 +1,14 @@
-from __future__ import annotations
-
-import os
-import sys
-
-from openai import OpenAI
-
-from app.core.prompts import load_prompt
-
-
-def _required(name: str) -> str:
-    v = os.getenv(name)
-    if not v:
-        print(f"[error] Missing env var: {name}", file=sys.stderr)
-        sys.exit(2)
-    return v
-
+from app.services.chat_completion_service import ChatCompletionService
 
 def main() -> None:
-    # Keep code provider-agnostic: only read OpenAI-compatible env vars.
-    api_key = _required("OPENAI_API_KEY")
-    base_url = os.getenv("OPENAI_BASE_URL")  # optional for real OpenAI
-    model = os.getenv("OPENAI_MODEL", "qwen-plus")
-
-    client = OpenAI(api_key=api_key, base_url=base_url)
-
-    system_prompt = load_prompt("system_prompt")
-
-    resp = client.chat.completions.create(
-        model=model,
+    service = ChatCompletionService()
+    text = service.create(
         messages=[
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": "Hello! Briefly explain what an LLM is."},
-        ],
-        temperature=0.3,
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "你好，请用一句话介绍你自己。"},
+        ]
     )
-
-    print(resp.choices[0].message.content)
-
+    print(text)
 
 if __name__ == "__main__":
     main()

--- a/scripts/run_agent_once.py
+++ b/scripts/run_agent_once.py
@@ -1,3 +1,4 @@
+from app.services.chat_completion_service import ChatCompletionService
 from pathlib import Path
 import argparse
 import json
@@ -8,6 +9,9 @@ from openai import OpenAI
 
 
 def load_text(path: str) -> str:
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Input file not found: {p.resolve()}")
     return Path(path).read_text(encoding="utf-8")
 
 
@@ -87,21 +91,15 @@ def main():
 
     system_prompt = load_text("app/prompts/system//agent_system.md")
 
-    client = OpenAI(
-        api_key=os.getenv("OPENAI_API_KEY"),
-        base_url=os.getenv("OPENAI_BASE_URL"),
-    )
-
-    response = client.chat.completions.create(
-        model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+    service = ChatCompletionService()
+    raw = service.create(
         messages=[
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_input},
         ],
         temperature=0.2,
     )
-
-    raw = response.choices[0].message.content
+    
     payload = json.loads(raw)
     validate_payload(payload)
 


### PR DESCRIPTION
What

Add ChatCompletionService in app/services/ as the single place for OpenAI-compatible chat completion calls.

Update demo scripts to call the service instead of instantiating OpenAI() directly.

Why

Enforce a clear boundary: scripts/ are demos/experiments; app/ owns reusable application capabilities.

Make future integration (RAG/Agent/workflows) a “swap implementation” change rather than a structural rewrite.

Changes

Added: app/services/chat_completion_service.py

Updated: scripts/chat_demo.py to use the service

Updated: scripts/run_agent_once.py to use the service (kept agent orchestration in script, moved model call behind the service)

How to verify

PYTHONPATH=. python scripts/chat_demo.py

PYTHONPATH=. python scripts/run_agent_once.py "your query"

Notes

This PR intentionally focuses on chat completion only; embeddings/model listing remain in scripts for now.