### PR TITLE
test(contracts): generate samples for plan execution contract

### DIFF
--- a/docs/samples/agent_execution_plan_sample.json
+++ b/docs/samples/agent_execution_plan_sample.json
@@ -1,36 +1,35 @@
 {
-  "task_summary": "Demonstrate failure vs blocking semantics for unknown tools and dependencies",
+  "task_summary": "echo a message then read current time",
   "assumptions": [
-    "The executor fails a step when a tool is unknown",
-    "Downstream steps are skipped when dependencies are not satisfied",
-    "The executor appends a __meta__ record at the end of execution_results"
+    "tool registry provides echo_tool and get_time"
   ],
   "risks": [
-    "If step ordering is incorrect, dependency checks may block execution",
-    "If the registry changes, tool availability assumptions may become invalid"
+    "time output format may vary by environment"
   ],
   "steps": [
     {
       "step_id": "step_1",
-      "title": "Attempt an unknown tool to trigger a failure",
-      "description": "Call a non-existent tool name to force the executor to mark this step failed.",
+      "title": "echo the message",
+      "description": "Call echo_tool with a short text.",
       "dependencies": [],
-      "deliverable": "A failed execution result with an error message describing unknown tool.",
-      "acceptance": "execution_results[step_1].ok=false and execution_results[step_1].error contains 'Unknown tool'.",
+      "deliverable": "A tool output containing the echoed text.",
+      "acceptance": "execution_results contains step_1 ok=true and output.echo is present.",
       "tool": {
-        "name": "no_such_tool",
-        "args": {}
+        "name": "echo_tool",
+        "args": {
+          "text": "hello"
+        }
       }
     },
     {
       "step_id": "step_2",
-      "title": "Downstream step should be skipped due to unmet dependency",
-      "description": "This step depends on step_1 and should be skipped when step_1 fails.",
+      "title": "get current time",
+      "description": "Call get_time after step_1 succeeds.",
       "dependencies": [
         "step_1"
       ],
-      "deliverable": "A skipped execution result with dependency-not-satisfied reason.",
-      "acceptance": "execution_results[step_2].skipped=true and reason contains 'dependency not satisfied'.",
+      "deliverable": "A tool output containing current time fields.",
+      "acceptance": "execution_results contains step_2 ok=true and output is JSON-safe.",
       "tool": {
         "name": "get_time",
         "args": {}

--- a/docs/samples/agent_plan_sample.json
+++ b/docs/samples/agent_plan_sample.json
@@ -1,55 +1,23 @@
 {
-  "task_summary": "Validate a plan contract and demonstrate deterministic tool execution",
+  "task_summary": "echo a short message",
   "assumptions": [
-    "The tool registry contains echo_tool and get_time",
-    "The executor enforces dependency resolution and produces execution_results"
+    "inputs are provided by user"
   ],
   "risks": [
-    "Unknown tools may cause a step to fail and block downstream steps",
-    "Unknown dependencies may block execution at planning time or during execution"
+    "none"
   ],
   "steps": [
     {
       "step_id": "step_1",
-      "title": "Emit a deterministic preflight note",
-      "description": "Use echo_tool to record a stable preflight message for traceability.",
+      "title": "echo the message",
+      "description": "Call echo_tool with a short text.",
       "dependencies": [],
-      "deliverable": "A preflight note captured via echo_tool output.",
-      "acceptance": "execution_results contains step_1 with ok=true and output.echo equals the provided text.",
+      "deliverable": "A tool output containing the echoed text.",
+      "acceptance": "execution_results contains step_1 with ok=true and output.echo equals the input text.",
       "tool": {
         "name": "echo_tool",
         "args": {
-          "text": "Preflight: validate contract fields and dependency semantics."
-        }
-      }
-    },
-    {
-      "step_id": "step_2",
-      "title": "Query current time from tool",
-      "description": "Call get_time to obtain the current time in a JSON-safe format.",
-      "dependencies": [
-        "step_1"
-      ],
-      "deliverable": "A JSON-safe timestamp returned by get_time.",
-      "acceptance": "execution_results contains step_2 with ok=true and output is JSON-safe.",
-      "tool": {
-        "name": "get_time",
-        "args": {}
-      }
-    },
-    {
-      "step_id": "step_3",
-      "title": "Summarize the run deterministically",
-      "description": "Use echo_tool to summarize what was executed and what outputs were produced.",
-      "dependencies": [
-        "step_2"
-      ],
-      "deliverable": "A summary note captured via echo_tool output.",
-      "acceptance": "execution_results contains step_3 with ok=true and output.echo includes references to step_1 and step_2.",
-      "tool": {
-        "name": "echo_tool",
-        "args": {
-          "text": "Summary: executed step_1 preflight, step_2 get_time, and produced JSON-safe outputs."
+          "text": "hello"
         }
       }
     }

--- a/scripts/generate_samples.py
+++ b/scripts/generate_samples.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+SAMPLES_DIR = Path("docs/samples")
+
+
+def _write_json(path: Path, obj: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def build_plan_sample() -> Dict[str, Any]:
+    """
+    A minimal plan payload sample that matches the plan contract.
+    """
+    return {
+        "task_summary": "echo a short message",
+        "assumptions": ["inputs are provided by user"],
+        "risks": ["none"],
+        "steps": [
+            {
+                "step_id": "step_1",
+                "title": "echo the message",
+                "description": "Call echo_tool with a short text.",
+                "dependencies": [],
+                "deliverable": "A tool output containing the echoed text.",
+                "acceptance": "execution_results contains step_1 with ok=true and output.echo equals the input text.",
+                "tool": {"name": "echo_tool", "args": {"text": "hello"}},
+            }
+        ],
+    }
+
+
+def build_execution_plan_sample() -> Dict[str, Any]:
+    """
+    A slightly richer plan payload sample that includes a dependency.
+    """
+    return {
+        "task_summary": "echo a message then read current time",
+        "assumptions": ["tool registry provides echo_tool and get_time"],
+        "risks": ["time output format may vary by environment"],
+        "steps": [
+            {
+                "step_id": "step_1",
+                "title": "echo the message",
+                "description": "Call echo_tool with a short text.",
+                "dependencies": [],
+                "deliverable": "A tool output containing the echoed text.",
+                "acceptance": "execution_results contains step_1 ok=true and output.echo is present.",
+                "tool": {"name": "echo_tool", "args": {"text": "hello"}},
+            },
+            {
+                "step_id": "step_2",
+                "title": "get current time",
+                "description": "Call get_time after step_1 succeeds.",
+                "dependencies": ["step_1"],
+                "deliverable": "A tool output containing current time fields.",
+                "acceptance": "execution_results contains step_2 ok=true and output is JSON-safe.",
+                "tool": {"name": "get_time", "args": {}},
+            },
+        ],
+    }
+
+
+def main() -> int:
+    plan_sample = build_plan_sample()
+    exec_plan_sample = build_execution_plan_sample()
+
+    _write_json(SAMPLES_DIR / "agent_plan_sample.json", plan_sample)
+    _write_json(SAMPLES_DIR / "agent_execution_plan_sample.json", exec_plan_sample)
+
+    print("[OK] generated samples:")
+    print(" - docs/samples/agent_plan_sample.json")
+    print(" - docs/samples/agent_execution_plan_sample.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_execution_semantics.py
+++ b/scripts/verify_execution_semantics.py
@@ -6,6 +6,10 @@ from typing import Any, Dict, Literal, Tuple
 from app.agents.plan_executor import execute_plan
 from app.agents.plan_validator import validate_execution_results, validate_plan_payload
 
+from pathlib import Path
+import subprocess
+import sys
+
 
 Expectation = Literal["REJECT", "FAILED", "BLOCKED"]
 PlanPolicy = Literal["REQUIRE_VALID", "ALLOW_ERRORS"]
@@ -53,6 +57,11 @@ def _assert_task_status(meta: Dict[str, Any], expected: str) -> list[str]:
 
 
 def main() -> int:
+    # Keep docs/samples in sync with the current contract.
+    gen = Path("scripts/generate_samples.py")
+    if gen.exists():
+        subprocess.run([sys.executable, str(gen)], check=True)
+
     # (case_name, payload, expected_task_status, plan_policy)
     cases: list[Tuple[str, Dict[str, Any], Expectation, PlanPolicy]] = []
 


### PR DESCRIPTION
Adds a dedicated generator for docs/samples JSON outputs.

verify_execution_semantics now regenerates samples consistently.