### PR TITLE
docs(contracts): add runnable contract verification guide

### DIFF
--- a/docs/guide/contract-verification.md
+++ b/docs/guide/contract-verification.md
@@ -1,0 +1,48 @@
+# Contract verification guide
+
+This repo includes a small, runnable contract verification suite that enforces:
+
+- Plan payload schema (planner contract)
+- Dependency semantics (blocked vs failed)
+- Tool whitelist behavior (unknown tool fails, downstream skipped)
+- Execution summary / meta status invariants
+
+## Quick commands
+
+### 1) Compile-time sanity checks
+
+```bash
+python -m py_compile app/agents/plan_executor.py
+python -m py_compile app/agents/plan_validator.py
+python -m py_compile app/agents/runner.py
+python -m py_compile scripts/verify_execution_semantics.py
+python -m py_compile scripts/generate_samples.py
+```
+
+### 2) Verify execution semantics
+
+```bash
+PYTHONPATH=. python scripts/verify_execution_semantics.py
+```
+
+Expected output ends with:
+
+- `[PASS] contract execution semantics verified`
+
+### 3) Regenerate public samples
+
+```bash
+PYTHONPATH=. python scripts/generate_samples.py
+```
+
+This writes/updates:
+
+- `docs/samples/agent_plan_sample.json`
+- `docs/samples/agent_execution_plan_sample.json`
+
+## References
+
+- `docs/architecture/planner-contract.md`
+- `docs/architecture/plan_execution_contract.md`
+- `docs/architecture/plan-executor-semantics.md`
+- `docs/architecture/execution-contract-closure.md`


### PR DESCRIPTION
What

This PR adds a runnable contract verification guide that documents how to:

Validate planner payload contracts

Verify execution semantics (blocked vs failed)

Enforce tool whitelist behavior

Assert execution summary / meta status invariants

Regenerate public JSON samples

It provides a single, canonical entry point for contract-level verification.

Why

The execution pipeline now has clearly defined planner, executor, and runner contracts, but they were previously scattered across multiple files.

This guide closes the loop by:

Making the contracts executable, not just descriptive

Ensuring future changes can be verified via a single command

Providing a stable reference for reviewers and contributors

Turning the contract definitions into a runnable specification

Scope

This PR does not change runtime logic.
It only adds documentation that binds together:

planner-contract.md

plan_execution_contract.md

plan-executor-semantics.md

execution-contract-closure.md

verify_execution_semantics.py

generate_samples.py

How to verify
python -m py_compile app/agents/plan_executor.py
python -m py_compile app/agents/plan_validator.py
python -m py_compile app/agents/runner.py
python -m py_compile scripts/verify_execution_semantics.py
python -m py_compile scripts/generate_samples.py

PYTHONPATH=. python scripts/verify_execution_semantics.py
# Expected:
# [PASS] contract execution semantics verified

PYTHONPATH=. python scripts/generate_samples.py
