### PR TITLE
contract: validate known tools and sync verifier with tool registry

### DIFF
--- a/app/agents/plan_validator.py
+++ b/app/agents/plan_validator.py
@@ -8,6 +8,7 @@ def validate_plan_payload(
     *,
     strict_tool_object: bool = True,
     strict_dep_order: bool = True,
+    known_tools: set[str] | None = None,
 ) -> list[str]:
     """
     Plan payload contract validation.
@@ -128,15 +129,21 @@ def validate_plan_payload(
                 else:
                     if not tool.strip():
                         errors.append(f"steps[{i}].tool must be a non-empty string")
+                    else:
+                        if known_tools is not None and tool.strip() not in known_tools:
+                            errors.append(f"steps[{i}] has unknown tool: {tool.strip()}")
+                            
                     args = s.get("args")
                     if args is not None and not isinstance(args, dict):
                         errors.append(f"steps[{i}].args must be an object when provided")
-
             elif isinstance(tool, dict):
                 name = tool.get("name")
                 args = tool.get("args", {})
                 if not isinstance(name, str) or not name.strip():
                     errors.append(f"steps[{i}].tool.name must be a non-empty string")
+                else:
+                    if known_tools is not None and name.strip() not in known_tools:
+                        errors.append(f"steps[{i}] has unknown tool: {name.strip()}")
                 if args is None:
                     args = {}
                 if not isinstance(args, dict):

--- a/app/tools/registry.py
+++ b/app/tools/registry.py
@@ -45,6 +45,24 @@ def list_tools() -> List[Dict[str, Any]]:
 
     return out
 
+def list_tool_names() -> List[str]:
+    """
+    Export canonical tool names for contract validation.
+
+    Rules:
+    - Only include canonical "main name" entries (key == tool.name)
+    - Exclude compatibility alias keys (e.g. time_tool/get_time_tool)
+    - Return a sorted list for stable tests
+    """
+    names: set[str] = set()
+
+    for key, t in _TOOL_REGISTRY.items():
+        if key != t.name:
+            continue
+        if t.name:
+            names.add(t.name)
+
+    return sorted(names)
 
 def dispatch_tool(name: str, args: Dict[str, Any]) -> Dict[str, Any]:
     tool = get_tool(name)


### PR DESCRIPTION
Adds optional known_tools check to plan contract validation to fail fast on unknown tools.

Updates execution semantics verifier to cover:

contract-level REJECT for unknown tools

executor-level FAILED when plan errors are allowed

Exports canonical tool names from tool registry to keep verifier in sync and avoid drift.