### PR TITLE
chore(cli): document repeat stats and client timeout defaults

### DIFF
--- a/docs/architecture/cli-repeat-and-timeout-notes.md
+++ b/docs/architecture/cli-repeat-and-timeout-notes.md
@@ -1,0 +1,12 @@
+# CLI repeat & chat client hardening (timeouts / trust_env)
+
+This repo provides a minimal CLI (`scripts/run_agent_once.py`) to validate agent JSON contracts.
+
+Key hardening:
+- httpx timeouts enabled to avoid hanging requests
+- `trust_env` default is false to prevent accidental proxy env issues
+- `--repeat` mode to quantify stability; `--stop-on-rate-limit` for clean runs
+
+Quick verification examples:
+- `python scripts/run_agent_once.py "<prompt>" --expected-steps 3`
+- `python scripts/run_agent_once.py "<prompt>" --expected-steps 3 --repeat 5 --sleep-ms 600 --stop-on-rate-limit`


### PR DESCRIPTION
what：add minimal notes for repeat + timeout/trust_env

why：prevent hang/proxy issues + quantify stability

how to verify：贴你跑过的 3 条命令（不贴输出）