### PR TITLE
Stabilize runner: step normalization, expected_steps safety net, and degraded quality gate

### DIFF
--- a/app/agents/plan_executor.py
+++ b/app/agents/plan_executor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 # Boundary: do NOT import runner/entry_shell; do NOT own contract rules (keep those in plan_validator/prompt)
 # See: docs/architecture/modules.md
 
-from typing import Any, Optional
+from typing import Any, Optional, Tuple
 
 from app.tools.registry import dispatch_tool
 
@@ -34,14 +34,54 @@ def _parse_tool(step: dict[str, Any]) -> tuple[str, dict[str, Any]]:
     raise ValueError("step.tool must be a string or an object")
 
 
+def _detect_degraded(tool_name: str, args: dict[str, Any]) -> Tuple[bool, Optional[str], Optional[str]]:
+    """
+    Best-effort degraded detection (no coupling to planner internals).
+
+    We consider a step "degraded" when:
+    - tool_name == "echo_tool"
+    - args.text suggests "unknown tool" / "tool not found" fallback
+
+    Returns: (degraded, degraded_reason, degraded_from)
+    """
+    if tool_name != "echo_tool":
+        return False, None, None
+
+    text = args.get("text")
+    if not isinstance(text, str) or not text.strip():
+        return False, None, None
+
+    low = text.lower()
+
+    triggers = [
+        "不存在",
+        "未实现",
+        "unknown tool",
+        "tool not found",
+        "no_such_tool",
+        "降级",
+        "占位",
+        "fallback",
+    ]
+    if not any(t in text for t in triggers) and not any(t in low for t in triggers):
+        return False, None, None
+
+    degraded_from: Optional[str] = None
+    if "no_such_tool" in low:
+        degraded_from = "no_such_tool"
+
+    reason = "degraded: fallback-to-echo_tool (unknown tool or placeholder)"
+    return True, reason, degraded_from
+
+
 def compute_task_status(execution_results: list[dict[str, Any]]) -> str:
     """
     Compute overall task status from per-step execution_results.
 
     Status priority:
-    1) BLOCKED: any step has unknown dependency OR is skipped due to dependency not satisfied
-    2) FAILED: any step failed (ok=false) and not skipped (excluding blocked cases)
-    3) PARTIAL: some ok and some skipped, with no blocked/failed
+    1) BLOCKED: any step has unknown dependency OR is skipped due to dependency not satisfied (hard)
+    2) FAILED: any step failed (ok=false) and not skipped
+    3) PARTIAL: some ok and some skipped (including strict-degraded skips)
     4) COMPLETED: all ok
 
     Notes:
@@ -70,6 +110,12 @@ def compute_task_status(execution_results: list[dict[str, Any]]) -> str:
         # not ok
         if skipped:
             any_skipped = True
+
+            # strict degraded: not a "hard blocked" dependency, treat as PARTIAL
+            if "dependency not satisfied (degraded)" in reason:
+                continue
+
+            # hard dependency not satisfied => BLOCKED
             if "dependency not satisfied" in reason:
                 return "BLOCKED"
             continue
@@ -80,14 +126,12 @@ def compute_task_status(execution_results: list[dict[str, Any]]) -> str:
 
         return "FAILED"
 
-    if any_skipped and any_ok:
-        return "PARTIAL"
-    if any_skipped and not any_ok:
+    if any_skipped:
         return "PARTIAL"
     return "COMPLETED"
 
 
-def execute_plan(payload: dict[str, Any]) -> dict[str, Any]:
+def execute_plan(payload: dict[str, Any], *, strict_degraded: bool = False) -> dict[str, Any]:
     """
     Execute tools described in payload["steps"][].tool
     Returns: payload + execution_results (JSON-safe)
@@ -97,6 +141,13 @@ def execute_plan(payload: dict[str, Any]) -> dict[str, Any]:
     - dependency failed/skipped -> skip that step (do not execute)
     - unknown tool -> mark that step failed; downstream deps will be skipped
     - append a __meta__ summary as the LAST execution_result
+
+    Degraded semantics:
+    - degraded means "tool ran ok, but semantics are a placeholder/fallback".
+
+    strict_degraded:
+    - False (default): degraded does NOT block downstream deps (current behavior)
+    - True: degraded is treated as NOT satisfiable dependency for downstream steps
     """
     steps: list[dict[str, Any]] = payload.get("steps", []) or []
     results: list[dict[str, Any]] = []
@@ -107,6 +158,7 @@ def execute_plan(payload: dict[str, Any]) -> dict[str, Any]:
         if isinstance(sid, str) and sid.strip():
             declared_ids.add(sid)
 
+    # status for dependency checks
     status: dict[str, dict[str, Any]] = {}
 
     for step in steps:
@@ -120,6 +172,9 @@ def execute_plan(payload: dict[str, Any]) -> dict[str, Any]:
             "ok": True,
             "skipped": False,
             "reason": None,
+            "degraded": False,
+            "degraded_reason": None,
+            "degraded_from": None,
         }
 
         # --- dependency existence check ---
@@ -141,33 +196,48 @@ def execute_plan(payload: dict[str, Any]) -> dict[str, Any]:
             }
             results.append(r)
             if isinstance(step_id, str):
-                status[step_id] = {"ok": False, "skipped": False}
+                status[step_id] = {"ok": False, "skipped": False, "degraded": False}
             continue
 
-        # --- dependency success check ---
+        # --- dependency satisfiable check ---
         failed_deps: list[str] = []
+        degraded_deps: list[str] = []
+
         if isinstance(deps, list):
             for d in deps:
                 st = status.get(d)
                 if (not st) or (not st.get("ok", False)) or st.get("skipped", False):
                     failed_deps.append(d)
+                    continue
+                if strict_degraded and st.get("degraded", False):
+                    degraded_deps.append(d)
 
-        if failed_deps:
+        if failed_deps or degraded_deps:
+            if degraded_deps and not failed_deps:
+                reason = f"dependency not satisfied (degraded): {degraded_deps}"
+            else:
+                # if any hard failed deps exist, we keep it as hard dependency not satisfied
+                all_bad = failed_deps + degraded_deps
+                reason = f"dependency not satisfied: {all_bad}"
+
             r = {
                 **base,
                 "ok": False,
                 "skipped": True,
-                "reason": f"dependency not satisfied: {failed_deps}",
+                "reason": reason,
             }
             results.append(r)
             if isinstance(step_id, str):
-                status[step_id] = {"ok": False, "skipped": True}
+                status[step_id] = {"ok": False, "skipped": True, "degraded": False}
             continue
 
         # --- execute tool ---
         try:
             tool_name, args = _parse_tool(step)
             out = dispatch_tool(tool_name, args)
+
+            degraded, degraded_reason, degraded_from = _detect_degraded(tool_name, args)
+
             r = {
                 **base,
                 "tool": tool_name,
@@ -175,10 +245,13 @@ def execute_plan(payload: dict[str, Any]) -> dict[str, Any]:
                 "skipped": False,
                 "reason": None,
                 "output": out,
+                "degraded": degraded,
+                "degraded_reason": degraded_reason,
+                "degraded_from": degraded_from,
             }
             results.append(r)
             if isinstance(step_id, str):
-                status[step_id] = {"ok": True, "skipped": False}
+                status[step_id] = {"ok": True, "skipped": False, "degraded": degraded}
         except Exception as e:
             inferred_tool = None
             if tool_name:
@@ -202,7 +275,7 @@ def execute_plan(payload: dict[str, Any]) -> dict[str, Any]:
             }
             results.append(r)
             if isinstance(step_id, str):
-                status[step_id] = {"ok": False, "skipped": False}
+                status[step_id] = {"ok": False, "skipped": False, "degraded": False}
 
     task_status = compute_task_status(results)
 
@@ -214,6 +287,15 @@ def execute_plan(payload: dict[str, Any]) -> dict[str, Any]:
         for r in results
         if r.get("step_id") != "__meta__" and (not r.get("ok")) and (not r.get("skipped", False))
     )
+
+    degraded_steps: list[str] = []
+    for r in results:
+        if r.get("step_id") == "__meta__":
+            continue
+        if r.get("degraded") is True:
+            sid = r.get("step_id")
+            if isinstance(sid, str):
+                degraded_steps.append(sid)
 
     summary_reason = None
     if task_status == "PARTIAL":
@@ -229,8 +311,12 @@ def execute_plan(payload: dict[str, Any]) -> dict[str, Any]:
         sid = r.get("step_id")
         if sid == "__meta__":
             continue
-        msg = (r.get("reason") or "") + " " + (r.get("error") or "")
-        if r.get("skipped") and "dependency not satisfied" in (r.get("reason") or ""):
+
+        reason = (r.get("reason") or "")
+        msg = reason + " " + (r.get("error") or "")
+
+        # hard blocked only (exclude strict-degraded skips)
+        if r.get("skipped") and "dependency not satisfied" in reason and "dependency not satisfied (degraded)" not in reason:
             if isinstance(sid, str):
                 blocked_steps.append(sid)
         elif (not r.get("ok")) and (not r.get("skipped", False)):
@@ -254,9 +340,12 @@ def execute_plan(payload: dict[str, Any]) -> dict[str, Any]:
                 "ok": ok_count,
                 "skipped": skipped_count,
                 "failed": failed_count,
+                "degraded_count": len(degraded_steps),
             },
+            "degraded_steps": degraded_steps,
             "blocked_steps": blocked_steps,
             "failed_steps": failed_steps,
+            "strict_degraded": strict_degraded,
         }
     )
 


### PR DESCRIPTION
Summary

This PR hardens the runner execution pipeline against common LLM instability issues by adding deterministic normalization, step count enforcement, and a degraded quality gate.

It ensures that the runner behaves predictably even when the model output is malformed, inconsistent, or partially invalid.

Key changes

Step ID normalization

Enforces continuous step IDs: step_1..step_N

Rewrites dependencies accordingly

Prevents forward or missing references

expected_steps safety net

Pads missing steps with placeholders

Enforces exact step count when configured

Makes downstream execution deterministic

Degraded quality gate

Detects fallback/degraded tool usage

Optional strict mode converts degraded plans into PARTIAL

Prevents silent quality regression

Single-pass repair & replan

Automatic JSON repair when parsing or validation fails

Single replan attempt on FAILED/BLOCKED/PARTIAL execution

Why this is needed

LLM outputs are probabilistic and can violate structural contracts (e.g., step numbering drift, invalid dependencies, unknown tools).
This PR ensures the runner is structure-driven, not language-driven, and guarantees contract correctness before execution.

Guarantees

After this PR:

Step IDs are always contiguous and valid

Dependencies always reference earlier steps

Step count is deterministic when expected_steps is set

Degraded execution can be explicitly gated

The runner never silently accepts malformed plans

Non-goals

This PR intentionally does not attempt to semantically fix natural language fields (title, description, etc.).
The runner treats these as informational only and relies on structural contracts.