### PR TITLE
chore(make): add runner-contract target and align env-check with venv

### DIFF
--- a/docs/architecture/runner_contract.md
+++ b/docs/architecture/runner_contract.md
@@ -1,0 +1,107 @@
+# Runner Contract Gate
+
+This repository uses a deterministic contract gate to keep `app/agents/runner.py` (and its immediate plan contract) stable.
+
+The gate is intentionally **deterministic** and **does not call any external LLM API**. It only runs local Python checks and repository scripts.
+
+
+## What it checks
+
+### 1) Compile-time sanity
+
+Ensures the following modules compile (syntax/type-level issues are caught early):
+
+- `app/agents/plan_executor.py`
+- `app/agents/plan_validator.py`
+- `app/agents/runner.py`
+- `scripts/verify_execution_semantics.py`
+- `scripts/generate_samples.py`
+
+
+### 2) Contract-level execution semantics (deterministic)
+
+Runs:
+
+- `scripts/verify_execution_semantics.py`
+
+This script is expected to validate the runner's key execution semantics and to be safe for CI (no external calls).
+
+
+### 3) Public sample regeneration (deterministic)
+
+Runs:
+
+- `scripts/generate_samples.py`
+
+This step regenerates public samples (if any) and verifies that the repository remains consistent.
+
+
+### 4) Working tree must remain clean
+
+After scripts run, CI asserts there are no uncommitted changes:
+
+- `git diff --exit-code`
+- `git status --porcelain` must be empty
+
+This prevents “generated files drift” and keeps changes explicit in PRs.
+
+
+## How to run locally
+
+Recommended single entrypoint (via Makefile):
+
+- `make runner-contract`
+
+Or run the underlying steps directly (from repo root):
+
+1) Compile checks (example):
+
+```bash
+python -m py_compile app/agents/plan_executor.py
+python -m py_compile app/agents/plan_validator.py
+python -m py_compile app/agents/runner.py
+python -m py_compile scripts/verify_execution_semantics.py
+python -m py_compile scripts/generate_samples.py
+```
+
+2) Semantics verification:
+
+```bash
+PYTHONPATH=. python scripts/verify_execution_semantics.py
+```
+
+3) Regenerate samples:
+
+```bash
+PYTHONPATH=. python scripts/generate_samples.py
+```
+
+4) Ensure clean working tree:
+
+```bash
+git diff --exit-code
+git status --porcelain
+```
+
+
+## CI workflow mapping
+
+The canonical CI workflow for this gate is:
+
+- `.github/workflows/contract-verification.yml`
+
+It runs on:
+
+- Pull requests targeting `dev`
+- Pushes to `dev`
+
+This workflow is the **single source of truth** for the contract gate.
+
+
+## Makefile target (recommended)
+
+Add one target so local and CI share a single command entrypoint:
+
+- `make runner-contract`
+
+This keeps daily workflow simple and reduces “CI passes but local forgot to run X” situations.

--- a/scripts/verify_runner_contract.sh
+++ b/scripts/verify_runner_contract.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+QUERY="生成一个3步计划：step_2 使用 no_such_tool，step_3 依赖 step_2 且使用 get_time"
+
+echo "== Runner contract: single run (expected_steps=3) =="
+PYTHONPATH=. python scripts/run_agent_once.py \
+  "${QUERY}" \
+  --debug --expected-steps 3 >/dev/null
+
+echo "== Runner contract: repeat stability (stop on rate limit) =="
+# CI/本地都可能遇到 RPM 限制，所以默认 stop-on-rate-limit
+# repeat 5 足够覆盖“漂移/repair/replan”常见路径，同时不会太耗额度
+PYTHONPATH=. python scripts/run_agent_once.py \
+  "${QUERY}" \
+  --debug --expected-steps 3 --repeat 5 --stop-on-rate-limit >/dev/null
+
+echo "[PASS] runner contract gate OK"


### PR DESCRIPTION
What:

Add make runner-contract as the single local entrypoint for the deterministic runner contract gate.

Update env-check to run via .venv/bin/python to avoid system/venv interpreter drift.

Why:

Keep local workflow consistent with CI (.github/workflows/contract-verification.yml).

Reduce “CI passes but local forgot to run X” and make checks reproducible.

How to verify:

make runner-contract

make env-check