### PR TITLE
test: lock ref resolution variants in execution semantics

### DIFF
--- a/scripts/verify_execution_semantics.py
+++ b/scripts/verify_execution_semantics.py
@@ -165,6 +165,70 @@ def main() -> int:
         )
     )
 
+    # Case 4: reference drift ".output.step_1.output.docs" should still work (planner sometimes emits this)
+    # This used to break summarize_tool because docs became a string instead of an array.
+    cases.append(
+        (
+            "ref_drift_output_step_1_output_docs_should_complete",
+            _base_payload(
+                "executor should resolve .output.step_1.output.docs to step_1.output.docs",
+                steps=[
+                    _base_step(
+                        "step_1",
+                        title="search workflow docs",
+                        dependencies=[],
+                        tool_name="search_tool",
+                        tool_args={"query": "workflow"},
+                    ),
+                    _base_step(
+                        "step_2",
+                        title="summarize using drift ref path",
+                        dependencies=["step_1"],
+                        tool_name="summarize_tool",
+                        tool_args={
+                            # Intentionally drifted reference form observed from planner output
+                            "docs": ".output.step_1.output.docs",
+                            "max_points": 2,
+                        },
+                    ),
+                ],
+            ),
+            "COMPLETED",
+            "ALLOW_ERRORS",
+        )
+    )
+
+    # Case 5: reference form "$step_1.output.docs" should also work (preferred explicit style)
+    cases.append(
+        (
+            "ref_dollar_step_1_output_docs_should_complete",
+            _base_payload(
+                "executor should resolve $step_1.output.docs to step_1.output.docs",
+                steps=[
+                    _base_step(
+                        "step_1",
+                        title="search workflow docs",
+                        dependencies=[],
+                        tool_name="search_tool",
+                        tool_args={"query": "workflow"},
+                    ),
+                    _base_step(
+                        "step_2",
+                        title="summarize using dollar ref",
+                        dependencies=["step_1"],
+                        tool_name="summarize_tool",
+                        tool_args={
+                            "docs": "$step_1.output.docs",
+                            "max_points": 2,
+                        },
+                    ),
+                ],
+            ),
+            "COMPLETED",
+            "ALLOW_ERRORS",
+        )
+    )
+
     for name, payload, expected, plan_policy in cases:
         _print(f"[{name}] payload", payload)
 


### PR DESCRIPTION
Add regression cases for docs reference variants: .output.docs, .output.step_1.output.docs, $step_1.output.docs

Keep contract semantics stable with executor-side resolution

Verified: PYTHONPATH=. python scripts/verify_execution_semantics.py ✅