### PR TITLE
feat(workflow): add CLI runner and local verification targets

### DIFF
--- a/scripts/run_workflow.py
+++ b/scripts/run_workflow.py
@@ -32,25 +32,22 @@ def main() -> int:
     parser.add_argument(
         "--json",
         action="store_true",
-        help="Print full final output as JSON (default).",
+        help="Print full final output as JSON.",
     )
     parser.add_argument(
         "--answer-only",
         action="store_true",
-        help="Print only final answer string.",
+        help="Print only final answer string (no JSON).",
     )
     args = parser.parse_args()
 
-    # Note: workflow_runner.run_minimal_workflow currently runs with trace=True in code.
-    # This CLI keeps a stable interface; if you later wire trace into runner, you can
-    # pass args.trace through without changing callers.
-    out: Dict[str, Any] = run_minimal_workflow(args.query)
+    out: Dict[str, Any] = run_minimal_workflow(args.query, trace=args.trace)
 
     if args.answer_only:
         print(out.get("answer", ""))
         return 0
 
-    # default: show json unless explicitly disabled in future
+    # default behavior: print JSON (keeping CLI convenient in pipelines)
     if args.json or True:
         print(_pretty(out))
         return 0

--- a/scripts/verify_workflow_cli.py
+++ b/scripts/verify_workflow_cli.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _run(cmd: list[str]) -> str:
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    if p.returncode != 0:
+        raise RuntimeError(
+            "Command failed\n"
+            f"cmd: {' '.join(cmd)}\n"
+            f"returncode: {p.returncode}\n"
+            f"stdout:\n{p.stdout}\n"
+            f"stderr:\n{p.stderr}\n"
+        )
+    return p.stdout
+
+
+def main() -> int:
+    py = sys.executable
+
+    # Case 1: answer-only should be non-empty and should NOT include trace markers by default
+    out1 = _run([py, "scripts/run_workflow.py", "帮我总结一下今天我做了什么", "--answer-only"])
+    if not out1.strip():
+        raise AssertionError("Expected non-empty answer-only output, got empty output.")
+    if "--- [1] BEFORE" in out1:
+        raise AssertionError("answer-only output should not include trace markers by default.")
+
+    # Case 2: trace mode should include trace markers (BEFORE/AFTER)
+    out2 = _run([py, "scripts/run_workflow.py", "帮我总结一下今天我做了什么", "--trace"])
+    if "--- [1] BEFORE input" not in out2:
+        raise AssertionError("Expected trace markers in output when --trace is set.")
+
+    print("[PASS] workflow CLI verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This PR introduces a minimal CLI interface and local verification flow for the workflow skeleton.

Changes

add scripts/run_workflow.py as a stable CLI entrypoint

support --trace and --answer-only modes

add scripts/verify_workflow_cli.py for local CLI regression checks

add make workflow and make workflow-cli-verify targets

Purpose

make workflow runnable without touching Python internals

standardize local execution similar to runner-contract gate

improve reproducibility and debugging

prepare for future LLM / RAG integration

Result

Developers can now:

run demo: make workflow

verify CLI: make workflow-cli-verify

No behavior change to core execution logic.