### PR TITLE
build: make platform installable and expose stable import surface

### DIFF
--- a/jinsie_agent_platform/__init__.py
+++ b/jinsie_agent_platform/__init__.py
@@ -1,0 +1,6 @@
+"""
+Public import surface for the platform.
+
+System projects should import from `jinsie_agent_platform.*`
+to avoid name collisions with their own `app/` packages.
+"""

--- a/jinsie_agent_platform/runner.py
+++ b/jinsie_agent_platform/runner.py
@@ -1,0 +1,11 @@
+"""
+Thin wrapper to expose stable imports for system repos.
+
+DO NOT implement business logic here.
+"""
+
+# TODO: replace the import path below with the real runner entry in your platform.
+# For now, we only provide a placeholder to make the package importable.
+
+def workflow_runner(*args, **kwargs):
+    raise NotImplementedError("workflow_runner is not wired yet. Please map to platform runner entry.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "jinsie-ai-agent-platform"
+version = "0.1.0"
+description = "Jinsie AI Agent Platform (importable base for system repos)"
+requires-python = ">=3.10"
+dependencies = []
+
+[tool.setuptools]
+packages = ["app", "scripts", "jinsie_agent_platform"]


### PR DESCRIPTION
Make the platform repo installable via pip editable mode.

- add pyproject.toml packaging config
- expose stable import surface (runner)
- prepare as shared base for downstream systems (RAG/Observability)
