### PR TITLE
feat: wire stable workflow_runner to platform agent runner

### DIFF
--- a/jinsie_agent_platform/runner.py
+++ b/jinsie_agent_platform/runner.py
@@ -4,8 +4,35 @@ Thin wrapper to expose stable imports for system repos.
 DO NOT implement business logic here.
 """
 
-# TODO: replace the import path below with the real runner entry in your platform.
-# For now, we only provide a placeholder to make the package importable.
+from __future__ import annotations
 
-def workflow_runner(*args, **kwargs):
-    raise NotImplementedError("workflow_runner is not wired yet. Please map to platform runner entry.")
+from typing import Any, Dict, Optional
+
+# Map to the real runner entry in your platform.
+from app.agents.runner import run_agent_once_json
+
+
+def workflow_runner(
+    user_input: str,
+    *,
+    debug: bool = False,
+    expected_steps: Optional[int] = None,
+    strict_degraded: bool = False,
+    prompt_path: str = "app/prompts/system/agent_system.md",
+    temperature: float = 0.2,
+    max_tokens: int = 512,
+) -> Dict[str, Any]:
+    """
+    Stable entry for system repos.
+
+    This is a thin wrapper that forwards to the platform runner.
+    """
+    return run_agent_once_json(
+        user_input,
+        prompt_path=prompt_path,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        debug=debug,
+        expected_steps=expected_steps,
+        strict_degraded=strict_degraded,
+    )


### PR DESCRIPTION
Summary

Wire jinsie_agent_platform.workflow_runner() to the platform runner (app.agents.runner.run_agent_once_json).

Motivation

Provide a stable import surface for system repos to integrate with the platform without importing internal app/* directly.

Scope

Thin wrapper only; no behavior changes to the runner implementation.